### PR TITLE
Align menu item spacing

### DIFF
--- a/contact_details.html
+++ b/contact_details.html
@@ -132,13 +132,13 @@
                 </svg>
             </div>
             <nav class="flex flex-col space-y-4">
-                <a href="contacts.html" id="contacts-link" class="nav-link active flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Kontakty"><i class="fas fa-address-book fa-lg"></i><span>Kontakty</span></a>
-                <a href="transactions.html" id="kanban-link" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Transakcje"><i class="fas fa-project-diagram fa-lg"></i><span>Transakcje</span></a>
-                <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Projekty"><i class="fas fa-folder-open fa-lg"></i><span>Projekty</span></a>
-                <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Zasoby"><i class="fas fa-box-open fa-lg"></i><span>Zasoby</span></a>
-                <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Raporty"><i class="fas fa-tachometer-alt fa-lg"></i><span>Raporty</span></a>
-                <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Baza wiedzy"><i class="fas fa-book fa-lg"></i><span>Baza wiedzy</span></a>
-                <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Ustawienia"><i class="fas fa-cog fa-lg"></i><span>Ustawienia</span></a>
+                <a href="contacts.html" id="contacts-link" class="nav-link active flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Kontakty"><i class="fas fa-address-book fa-lg"></i><span>Kontakty</span></a>
+                <a href="transactions.html" id="kanban-link" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Transakcje"><i class="fas fa-project-diagram fa-lg"></i><span>Transakcje</span></a>
+                <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Projekty"><i class="fas fa-folder-open fa-lg"></i><span>Projekty</span></a>
+                <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Zasoby"><i class="fas fa-box-open fa-lg"></i><span>Zasoby</span></a>
+                <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Raporty"><i class="fas fa-tachometer-alt fa-lg"></i><span>Raporty</span></a>
+                <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Baza wiedzy"><i class="fas fa-book fa-lg"></i><span>Baza wiedzy</span></a>
+                <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Ustawienia"><i class="fas fa-cog fa-lg"></i><span>Ustawienia</span></a>
             </nav>
         </aside>
 

--- a/contacts.html
+++ b/contacts.html
@@ -42,13 +42,13 @@
           </svg>
         </div>
         <nav class="flex flex-col space-y-4">
-          <a href="contacts.html" id="contacts-link" class="nav-link active flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Kontakty"><i class="fas fa-address-book fa-lg"></i><span>Kontakty</span></a>
-          <a href="transactions.html" id="kanban-link" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Transakcje"><i class="fas fa-project-diagram fa-lg"></i><span>Transakcje</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Projekty"><i class="fas fa-folder-open fa-lg"></i><span>Projekty</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Zasoby"><i class="fas fa-box-open fa-lg"></i><span>Zasoby</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Raporty"><i class="fas fa-tachometer-alt fa-lg"></i><span>Raporty</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Baza wiedzy"><i class="fas fa-book fa-lg"></i><span>Baza wiedzy</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Ustawienia"><i class="fas fa-cog fa-lg"></i><span>Ustawienia</span></a>
+          <a href="contacts.html" id="contacts-link" class="nav-link active flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Kontakty"><i class="fas fa-address-book fa-lg"></i><span>Kontakty</span></a>
+          <a href="transactions.html" id="kanban-link" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Transakcje"><i class="fas fa-project-diagram fa-lg"></i><span>Transakcje</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Projekty"><i class="fas fa-folder-open fa-lg"></i><span>Projekty</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Zasoby"><i class="fas fa-box-open fa-lg"></i><span>Zasoby</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Raporty"><i class="fas fa-tachometer-alt fa-lg"></i><span>Raporty</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Baza wiedzy"><i class="fas fa-book fa-lg"></i><span>Baza wiedzy</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Ustawienia"><i class="fas fa-cog fa-lg"></i><span>Ustawienia</span></a>
         </nav>
       </aside>
 

--- a/index.html
+++ b/index.html
@@ -42,13 +42,13 @@
           </svg>
         </div>
         <nav class="flex flex-col space-y-4">
-          <a href="contacts.html" id="contacts-link" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Kontakty"><i class="fas fa-address-book fa-lg"></i><span>Kontakty</span></a>
-          <a href="transactions.html" id="kanban-link" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Transakcje"><i class="fas fa-project-diagram fa-lg"></i><span>Transakcje</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Projekty"><i class="fas fa-folder-open fa-lg"></i><span>Projekty</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Zasoby"><i class="fas fa-box-open fa-lg"></i><span>Zasoby</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Raporty"><i class="fas fa-tachometer-alt fa-lg"></i><span>Raporty</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Baza wiedzy"><i class="fas fa-book fa-lg"></i><span>Baza wiedzy</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Ustawienia"><i class="fas fa-cog fa-lg"></i><span>Ustawienia</span></a>
+          <a href="contacts.html" id="contacts-link" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Kontakty"><i class="fas fa-address-book fa-lg"></i><span>Kontakty</span></a>
+          <a href="transactions.html" id="kanban-link" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Transakcje"><i class="fas fa-project-diagram fa-lg"></i><span>Transakcje</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Projekty"><i class="fas fa-folder-open fa-lg"></i><span>Projekty</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Zasoby"><i class="fas fa-box-open fa-lg"></i><span>Zasoby</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Raporty"><i class="fas fa-tachometer-alt fa-lg"></i><span>Raporty</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Baza wiedzy"><i class="fas fa-book fa-lg"></i><span>Baza wiedzy</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Ustawienia"><i class="fas fa-cog fa-lg"></i><span>Ustawienia</span></a>
         </nav>
       </aside>
 

--- a/transactions.html
+++ b/transactions.html
@@ -42,13 +42,13 @@
           </svg>
         </div>
         <nav class="flex flex-col space-y-4">
-          <a href="contacts.html" id="contacts-link" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Kontakty"><i class="fas fa-address-book fa-lg"></i><span>Kontakty</span></a>
-          <a href="transactions.html" id="kanban-link" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200 active" title="Transakcje"><i class="fas fa-project-diagram fa-lg"></i><span>Transakcje</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Projekty"><i class="fas fa-folder-open fa-lg"></i><span>Projekty</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Zasoby"><i class="fas fa-box-open fa-lg"></i><span>Zasoby</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Raporty"><i class="fas fa-tachometer-alt fa-lg"></i><span>Raporty</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Baza wiedzy"><i class="fas fa-book fa-lg"></i><span>Baza wiedzy</span></a>
-          <a href="#" class="nav-link flex items-center space-x-2 p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Ustawienia"><i class="fas fa-cog fa-lg"></i><span>Ustawienia</span></a>
+          <a href="contacts.html" id="contacts-link" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Kontakty"><i class="fas fa-address-book fa-lg"></i><span>Kontakty</span></a>
+          <a href="transactions.html" id="kanban-link" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200 active" title="Transakcje"><i class="fas fa-project-diagram fa-lg"></i><span>Transakcje</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Projekty"><i class="fas fa-folder-open fa-lg"></i><span>Projekty</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Zasoby"><i class="fas fa-box-open fa-lg"></i><span>Zasoby</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Raporty"><i class="fas fa-tachometer-alt fa-lg"></i><span>Raporty</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Baza wiedzy"><i class="fas fa-book fa-lg"></i><span>Baza wiedzy</span></a>
+          <a href="#" class="nav-link flex items-center p-3 rounded-lg text-gray-600 hover:bg-gray-200" title="Ustawienia"><i class="fas fa-cog fa-lg"></i><span>Ustawienia</span></a>
         </nav>
       </aside>
 


### PR DESCRIPTION
## Summary
- remove extra Tailwind `space-x-2` from sidebar links so icon spacing matches other pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e4e84bb488326bdc2f9432b17d85a