### PR TITLE
Integrate RFQ tab in offer details

### DIFF
--- a/assets/js/offer_details.js
+++ b/assets/js/offer_details.js
@@ -1,0 +1,96 @@
+document.addEventListener('DOMContentLoaded', function () {
+  // Tab switching logic
+  document.querySelectorAll('.tab-button').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      const target = btn.getAttribute('data-tab');
+      document.querySelectorAll('.tab-button').forEach(b => b.classList.remove('active'));
+      document.querySelectorAll('.tab-pane').forEach(pane => pane.classList.remove('active'));
+      btn.classList.add('active');
+      const pane = document.getElementById(target);
+      if (pane) pane.classList.add('active');
+    });
+  });
+
+  // RFQ tab logic
+  const loadBtn = document.getElementById('load-subs');
+  if (!loadBtn) return;
+  const sendBtn = document.getElementById('send-rfq');
+  const cancelBtn = document.getElementById('cancel-send');
+  const confirmBtn = document.getElementById('confirm-send');
+
+  let subcontractors = [];
+  let sentRequests = [];
+  let pendingIds = [];
+
+  loadBtn.addEventListener('click', loadSubcontractors);
+  sendBtn.addEventListener('click', showPreview);
+  cancelBtn.addEventListener('click', function() { toggleModal(false); });
+  confirmBtn.addEventListener('click', sendRFQ);
+
+  function loadSubcontractors() {
+    subcontractors = [
+      { id:'101', name:'Firma DachTech', email:'kontakt@dachtech.pl', region:'Mazowieckie', industry:'Pokrycia dachowe' },
+      { id:'102', name:'StalBud', email:'info@stalbud.pl', region:'Ma\u0142opolskie', industry:'Konstrukcje stalowe' },
+      { id:'103', name:'IzolacjePRO', email:'biuro@izolacjepro.pl', region:'Mazowieckie', industry:'Izolacje termiczne' },
+      { id:'104', name:'OknaDach', email:'sprzedaz@oknadach.pl', region:'\u015al\u0105skie', industry:'Monta\u017c okien dachowych' },
+      { id:'105', name:'DachStyl', email:'kontakt@dachstyl.pl', region:'Pomorskie', industry:'Renowacje dach\u00f3w' }
+    ];
+    renderSubcontractorTable();
+  }
+
+  function renderSubcontractorTable() {
+    const tbody = document.getElementById('subs-tbody');
+    tbody.innerHTML = '';
+    subcontractors.forEach(sub => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td><input type="checkbox" data-id="${sub.id}"></td><td>${sub.name}</td><td>${sub.email}</td><td>${sub.region}</td><td>${sub.industry}</td>`;
+      tbody.appendChild(tr);
+    });
+    document.getElementById('subs-table').style.display = 'table';
+    tbody.querySelectorAll('input[type=checkbox]').forEach(cb => cb.addEventListener('change', function() {
+      const any = Array.from(tbody.querySelectorAll('input[type=checkbox]')).some(c => c.checked);
+      sendBtn.disabled = !any;
+    }));
+  }
+
+  function showPreview() {
+    pendingIds = Array.from(document.querySelectorAll('#subs-tbody input[type=checkbox]:checked')).map(cb => cb.getAttribute('data-id'));
+    const template = `Temat: Zapytanie ofertowe dla projektu dachu\n\nSzanowni Pa\u0144stwo,\n\nZwracamy si\u0119 z pro\u015bb\u0105 o przes\u0142anie oferty na wykonanie projektu dachu.\nDane techniczne:\n- Klient: Jeronimo Martins Polska S.A.\n- Rozpocz\u0119cie: 01.09.2025\n- Lokalizacja: Warszawa\n\nZ powa\u017caniem,\nKosztorysant`;
+    document.getElementById('email-preview').textContent = template;
+    toggleModal(true);
+  }
+
+  function toggleModal(show) {
+    document.getElementById('preview-modal').style.display = show ? 'flex' : 'none';
+  }
+
+  function sendRFQ() {
+    const now = new Date().toISOString();
+    pendingIds.forEach(id => {
+      const sub = subcontractors.find(s => s.id === id);
+      sentRequests.push({ name: sub.name, email: sub.email, sentAt: now, status: 'Wys\u0142ane' });
+    });
+    renderSentTable();
+    document.querySelectorAll('#subs-tbody input[type=checkbox]').forEach(cb => cb.checked = false);
+    sendBtn.disabled = true;
+    toggleModal(false);
+  }
+
+  function renderSentTable() {
+    const tbody = document.getElementById('sent-tbody');
+    tbody.innerHTML = '';
+    sentRequests.forEach(req => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${req.name}</td><td>${req.email}</td><td>${new Date(req.sentAt).toLocaleString()}</td><td>${req.status}</td>`;
+      tbody.appendChild(tr);
+    });
+  }
+
+  setInterval(function() {
+    sentRequests.forEach(r => {
+      if (r.status === 'Wys\u0142ane') r.status = 'Odczytane';
+      else if (r.status === 'Odczytane') r.status = 'Odpowiedziane';
+    });
+    renderSentTable();
+  }, 15000);
+});

--- a/offer_details.html
+++ b/offer_details.html
@@ -107,6 +107,23 @@
         .tab-content { padding: 0; overflow-y: auto; flex: 1; }
         .tab-pane { display: none; }
         .tab-pane.active { display: block; padding: 20px; }
+
+        /* RFQ tab styles */
+        #rfq-tab { padding: 20px; }
+        #rfq-tab h2 { margin-top: 0; color: #ed7d23; }
+        #rfq-tab section { margin-bottom: 30px; }
+        #rfq-tab table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+        #rfq-tab th, #rfq-tab td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        #rfq-tab th { background: #f8f8f8; }
+        #rfq-tab button { background: #ed7d23; color: #fff; border: none; padding: 10px 15px; border-radius: 4px; cursor: pointer; font-size: 14px; }
+        #rfq-tab button:disabled { background: #ccc; cursor: not-allowed; }
+        .modal-overlay { display: none; position: fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); justify-content:center; align-items:center; }
+        .modal { background:#fff; padding:20px; border-radius:4px; width:80%; max-width:600px; max-height:80%; overflow:auto; }
+        .modal-header { font-size:18px; margin-bottom:10px; }
+        .modal-body { margin-bottom:10px; }
+        .modal-footer { text-align:right; }
+        .modal-footer button { margin-left:10px; }
+        pre { background:#f4f4f4; padding:10px; border-radius:4px; white-space:pre-wrap; word-wrap:break-word; }
     </style>
 </head>
 <body>
@@ -181,10 +198,58 @@
                     <!-- Tasks content -->
                 </div>
                 <div class="tab-pane" id="rfq">
-                    <!-- RFQ content -->
+                    <div id="rfq-tab">
+                        <h2>Zapytanie ofertowe (Symulacja)</h2>
+                        <section id="subcontractor-list">
+                            <h3>Wybór podwykonawców</h3>
+                            <button id="load-subs">Pobierz podwykonawców (symulacja)</button>
+                            <table id="subs-table" style="display:none;">
+                                <thead>
+                                    <tr>
+                                        <th>Wybierz</th>
+                                        <th>Nazwa</th>
+                                        <th>E-mail</th>
+                                        <th>Region</th>
+                                        <th>Branża</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="subs-tbody"></tbody>
+                            </table>
+                            <button id="send-rfq" disabled>Wyślij zapytanie</button>
+                        </section>
+                        <section id="sent-requests">
+                            <h3>Historia wysłanych zapytań</h3>
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th>Podwykonawca</th>
+                                        <th>E-mail</th>
+                                        <th>Data wysłania</th>
+                                        <th>Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="sent-tbody"></tbody>
+                            </table>
+                        </section>
+                    </div>
+
+                    <!-- Modal podglądu maila -->
+                    <div id="preview-modal" class="modal-overlay">
+                        <div class="modal">
+                            <div class="modal-header">Podgląd wiadomości e-mail</div>
+                            <div class="modal-body">
+                                <pre id="email-preview"></pre>
+                            </div>
+                            <div class="modal-footer">
+                                <button id="cancel-send">Anuluj</button>
+                                <button id="confirm-send">Potwierdź wysyłkę</button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+</div>
+<script src="assets/js/offer_details.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed content of `zapytanie_ofertowe.html` into the `Zapytania ofertowe` tab
- add styles for RFQ tab and modal preview
- implement tab switching and RFQ behaviour in new `offer_details.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870d67d8ff083268204834c1af09ff4