### PR TITLE
Add quick tab navigation to contact details

### DIFF
--- a/assets/js/contact_details.js
+++ b/assets/js/contact_details.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const tabButtons = document.querySelectorAll('.tab-button');
+  const tabPanes = document.querySelectorAll('.tab-pane');
+
+  function activateTab(tab) {
+    tabButtons.forEach(btn => {
+      const isActive = btn.getAttribute('data-tab') === tab;
+      btn.classList.toggle('active', isActive);
+    });
+    tabPanes.forEach(pane => {
+      const isActive = pane.id === tab;
+      pane.classList.toggle('active', isActive);
+    });
+  }
+
+  tabButtons.forEach(btn => {
+    btn.addEventListener('click', () => activateTab(btn.getAttribute('data-tab')));
+  });
+
+  document.querySelectorAll('[data-open-tab]').forEach(el => {
+    el.addEventListener('click', () => activateTab(el.getAttribute('data-open-tab')));
+  });
+});

--- a/contact_details.html
+++ b/contact_details.html
@@ -92,6 +92,12 @@
             background: #d97526;
         }
 
+        .quick-tab-btn {
+            border: none;
+            background: none;
+            cursor: pointer;
+        }
+
         /* Tabs area (right column) */
         .tabs-container {
             background: white;
@@ -140,6 +146,11 @@
             <div class="contact-info-header">
                 <div class="contact-avatar">JK</div>
                 <h3>Jan Kowalski</h3>
+                <div class="ml-auto flex space-x-2">
+                    <button class="quick-tab-btn p-2 text-gray-600 hover:text-gray-800" data-open-tab="notes" title="Notatki"><i class="fas fa-sticky-note"></i></button>
+                    <button class="quick-tab-btn p-2 text-gray-600 hover:text-gray-800" data-open-tab="messages" title="Wiadomości"><i class="fas fa-envelope"></i></button>
+                    <button class="quick-tab-btn p-2 text-gray-600 hover:text-gray-800" data-open-tab="tasks" title="Zadania"><i class="fas fa-tasks"></i></button>
+                </div>
             </div>
             <div class="info-group">
                 <div class="info-group-title">Informacje podstawowe</div>
@@ -195,5 +206,6 @@
             </div>
         </div>
     </div>
+<script src="assets/js/contact_details.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add quick access buttons in the contact header for Notes, Messages and Tasks
- implement tab switching logic and hook quick buttons to tabs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893130a9f808326b9689bc0a22b77ec