### PR TITLE
feat: add notes section to contact card

### DIFF
--- a/assets/js/contact_details.js
+++ b/assets/js/contact_details.js
@@ -20,4 +20,21 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('[data-open-tab]').forEach(el => {
     el.addEventListener('click', () => activateTab(el.getAttribute('data-open-tab')));
   });
+
+  const addNoteBtn = document.getElementById('add-note-btn');
+  const newNoteInput = document.getElementById('new-note-input');
+  const notesList = document.getElementById('notes-list');
+
+  if (addNoteBtn && newNoteInput && notesList) {
+    addNoteBtn.addEventListener('click', () => {
+      const text = newNoteInput.value.trim();
+      if (!text) return;
+      const date = new Date().toLocaleDateString('pl-PL');
+      const note = document.createElement('div');
+      note.className = 'border p-3 rounded';
+      note.innerHTML = `<div class="text-sm text-gray-600 mb-1">Anna Nowak – ${date}</div><div>${text}</div>`;
+      notesList.prepend(note);
+      newNoteInput.value = '';
+    });
+  }
 });

--- a/contact_details.html
+++ b/contact_details.html
@@ -195,7 +195,24 @@
                     <!-- Activity summary and items as before -->
                 </div>
                 <div class="tab-pane" id="notes">
-                    <!-- Notes content -->
+                    <div class="mb-4 flex space-x-2">
+                        <input id="new-note-input" type="text" placeholder="Dodaj notatkę" class="flex-1 border rounded px-3 py-2" />
+                        <button id="add-note-btn" class="brand-accent px-4 py-2 rounded text-white">Dodaj notatkę</button>
+                    </div>
+                    <div id="notes-list" class="space-y-4">
+                        <div class="border p-3 rounded">
+                            <div class="text-sm text-gray-600 mb-1">Anna Nowak – 01.04.2024</div>
+                            <div>Rozmowa telefoniczna z klientem w sprawie nowej oferty.</div>
+                        </div>
+                        <div class="border p-3 rounded">
+                            <div class="text-sm text-gray-600 mb-1">Piotr Zieliński – 20.03.2024</div>
+                            <div>Wysłał zapytanie o możliwości integracji.</div>
+                        </div>
+                        <div class="border p-3 rounded">
+                            <div class="text-sm text-gray-600 mb-1">Anna Nowak – 15.03.2024</div>
+                            <div>Dodano nowy kontakt do bazy CRM.</div>
+                        </div>
+                    </div>
                 </div>
                 <div class="tab-pane" id="messages">
                     <!-- Messages content -->


### PR DESCRIPTION
## Summary
- allow adding notes on contact details page
- show sample notes with author and date

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893155de8908326bc6f3a32c05c4a20