### PR TITLE
feat: display email history on contact details

### DIFF
--- a/assets/js/contact_details.js
+++ b/assets/js/contact_details.js
@@ -37,4 +37,36 @@ document.addEventListener('DOMContentLoaded', () => {
       newNoteInput.value = '';
     });
   }
+
+  const emailsList = document.getElementById('emails-list');
+  if (emailsList) {
+    const emails = [
+      {
+        user: 'Anna Nowak',
+        date: '01.04.2024',
+        subject: 'Powitanie i przedstawienie oferty',
+        body: 'Dzień dobry, w załączeniu przesyłam ofertę naszej firmy.'
+      },
+      {
+        user: 'Piotr Zieliński',
+        date: '20.03.2024',
+        subject: 'Przypomnienie o spotkaniu',
+        body: 'Przypominam o jutrzejszym spotkaniu online o 10:00.'
+      }
+    ];
+
+    emails.forEach(email => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'border p-3 rounded';
+      wrapper.innerHTML = `
+        <div class="flex justify-between items-center mb-1">
+          <div class="font-medium">${email.subject}</div>
+          <span class="bg-gray-200 text-gray-800 px-2 py-1 rounded text-xs">${email.user}</span>
+        </div>
+        <div class="text-sm text-gray-600 mb-1">Wysłano ${email.date}</div>
+        <div class="text-sm">${email.body}</div>
+      `;
+      emailsList.appendChild(wrapper);
+    });
+  }
 });

--- a/contact_details.html
+++ b/contact_details.html
@@ -148,7 +148,7 @@
                 <h3>Jan Kowalski</h3>
                 <div class="ml-auto flex space-x-2">
                     <button class="quick-tab-btn p-2 text-gray-600 hover:text-gray-800" data-open-tab="notes" title="Notatki"><i class="fas fa-sticky-note"></i></button>
-                    <button class="quick-tab-btn p-2 text-gray-600 hover:text-gray-800" data-open-tab="messages" title="Wiadomości"><i class="fas fa-envelope"></i></button>
+                    <button class="quick-tab-btn p-2 text-gray-600 hover:text-gray-800" data-open-tab="email" title="E-maile"><i class="fas fa-envelope"></i></button>
                     <button class="quick-tab-btn p-2 text-gray-600 hover:text-gray-800" data-open-tab="tasks" title="Zadania"><i class="fas fa-tasks"></i></button>
                 </div>
             </div>
@@ -187,7 +187,7 @@
             <div class="tabs-header">
                 <button class="tab-button active" data-tab="activity"><i class="fas fa-chart-line"></i> Podsumowanie aktywności</button>
                 <button class="tab-button" data-tab="notes"><i class="fas fa-sticky-note"></i> Notatki</button>
-                <button class="tab-button" data-tab="messages"><i class="fas fa-envelope"></i> Wiadomości</button>
+                <button class="tab-button" data-tab="email"><i class="fas fa-envelope"></i> E-maile</button>
                 <button class="tab-button" data-tab="tasks"><i class="fas fa-tasks"></i> Zadania</button>
             </div>
             <div class="tab-content">
@@ -214,8 +214,8 @@
                         </div>
                     </div>
                 </div>
-                <div class="tab-pane" id="messages">
-                    <!-- Messages content -->
+                <div class="tab-pane" id="email">
+                    <div id="emails-list" class="space-y-4"></div>
                 </div>
                 <div class="tab-pane" id="tasks">
                     <!-- Tasks content -->


### PR DESCRIPTION
## Summary
- add quick access and tab for email communication
- render sample email history with user labels

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68931a35ef7c8326af7ddfd7889909b7