### PR TITLE
Remove quick tab icons from contact details

### DIFF
--- a/assets/js/contact_details.js
+++ b/assets/js/contact_details.js
@@ -17,10 +17,6 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.addEventListener('click', () => activateTab(btn.getAttribute('data-tab')));
   });
 
-  document.querySelectorAll('[data-open-tab]').forEach(el => {
-    el.addEventListener('click', () => activateTab(el.getAttribute('data-open-tab')));
-  });
-
   const addNoteBtn = document.getElementById('add-note-btn');
   const newNoteInput = document.getElementById('new-note-input');
   const notesList = document.getElementById('notes-list');

--- a/contact_details.html
+++ b/contact_details.html
@@ -92,12 +92,6 @@
             background: #d97526;
         }
 
-        .quick-tab-btn {
-            border: none;
-            background: none;
-            cursor: pointer;
-        }
-
         /* Tabs area (right column) */
         .tabs-container {
             background: white;
@@ -146,11 +140,6 @@
             <div class="contact-info-header">
                 <div class="contact-avatar">JK</div>
                 <h3>Jan Kowalski</h3>
-                <div class="ml-auto flex space-x-2">
-                    <button class="quick-tab-btn p-2 text-gray-600 hover:text-gray-800" data-open-tab="notes" title="Notatki"><i class="fas fa-sticky-note"></i></button>
-                    <button class="quick-tab-btn p-2 text-gray-600 hover:text-gray-800" data-open-tab="email" title="E-maile"><i class="fas fa-envelope"></i></button>
-                    <button class="quick-tab-btn p-2 text-gray-600 hover:text-gray-800" data-open-tab="tasks" title="Zadania"><i class="fas fa-tasks"></i></button>
-                </div>
             </div>
             <div class="info-group">
                 <div class="info-group-title">Informacje podstawowe</div>


### PR DESCRIPTION
## Summary
- remove quick action icons for notes, emails, and tasks on the contact details page
- drop unused quick-tab event listener from contact details script

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68932e32eab083269b946c9b5c0138d9