### PR TITLE
Add modal for creating new contacts

### DIFF
--- a/assets/js/contacts.js
+++ b/assets/js/contacts.js
@@ -103,9 +103,36 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   const addNewButton = document.getElementById("add-new-button");
-  if (addNewButton) {
+  const modal = document.getElementById("add-contact-modal");
+  const cancelBtn = document.getElementById("cancel-add-contact");
+  const form = document.getElementById("add-contact-form");
+
+  if (addNewButton && modal) {
     addNewButton.addEventListener("click", () => {
-      showToast("Funkcja dodawania nowego kontaktu będzie dostępna wkrótce!");
+      modal.classList.remove("hidden");
+    });
+  }
+
+  if (cancelBtn && modal) {
+    cancelBtn.addEventListener("click", () => {
+      modal.classList.add("hidden");
+    });
+  }
+
+  if (modal) {
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) {
+        modal.classList.add("hidden");
+      }
+    });
+  }
+
+  if (form) {
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      modal.classList.add("hidden");
+      form.reset();
+      showToast("Kontakt został dodany");
     });
   }
 

--- a/contacts.html
+++ b/contacts.html
@@ -151,19 +151,167 @@
             <div id="pagination" class="mt-4 flex justify-center space-x-2"></div>
           </div>
         </div>
-      </main>
-    </div>
+        </main>
+      </div>
 
+      <!-- Add Contact Modal -->
+      <div
+        id="add-contact-modal"
+        class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden z-40"
+      >
+        <div class="bg-white p-6 rounded-lg w-full max-w-2xl">
+          <h2 class="text-xl font-semibold mb-4">Nowy kontakt</h2>
+          <form id="add-contact-form" class="space-y-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700"
+                >Imię i nazwisko <span class="text-red-500">*</span></label
+              >
+              <input
+                type="text"
+                id="contact-name"
+                required
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700"
+                >Właściciel kontaktu <span class="text-red-500">*</span></label
+              >
+              <select
+                id="contact-owner"
+                required
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              >
+                <option value="">Wybierz</option>
+                <option>Jan Kowalski</option>
+                <option>Agnieszka Nowak</option>
+                <option>Piotr Wiśniewski</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700"
+                >Typ kontaktu <span class="text-red-500">*</span></label
+              >
+              <select
+                id="contact-type"
+                required
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              >
+                <option value="">Wybierz</option>
+                <option>Klient</option>
+                <option>Potencjalny klient</option>
+                <option>Podwykonawca</option>
+                <option>Dostawca</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Numer telefonu</label>
+              <input
+                type="tel"
+                id="contact-phone"
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Adres email</label>
+              <input
+                type="email"
+                id="contact-email"
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Strona www</label>
+              <input
+                type="url"
+                id="contact-website"
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Nazwa firmy</label>
+              <input
+                type="text"
+                id="contact-company"
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">NIP</label>
+              <input
+                type="text"
+                id="contact-nip"
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Adres siedziby</label>
+              <input
+                type="text"
+                id="contact-address"
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Miejscowość</label>
+              <input
+                type="text"
+                id="contact-city"
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Województwo</label>
+              <input
+                type="text"
+                id="contact-voivodeship"
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700"
+                >Źródło pozyskania <span class="text-red-500">*</span></label
+              >
+              <select
+                id="contact-source"
+                required
+                class="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              >
+                <option value="">Wybierz</option>
+                <option>Internet</option>
+                <option>Polecenie</option>
+                <option>Targi</option>
+                <option>Inne</option>
+              </select>
+            </div>
+            <div class="flex justify-end space-x-2 pt-4">
+              <button
+                type="button"
+                id="cancel-add-contact"
+                class="px-4 py-2 bg-gray-200 rounded-md"
+              >
+                Anuluj
+              </button>
+              <button
+                type="submit"
+                class="px-4 py-2 brand-accent rounded-md text-white"
+              >
+                Zapisz
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
 
-    <!-- Toast Notification -->
-    <div
-      id="toast"
-      class="toast fixed bottom-5 right-5 bg-gray-800 text-white py-3 px-5 rounded-lg shadow-lg flex items-center space-x-3 z-50"
-    >
-      <i class="fas fa-check-circle text-green-400"></i>
-      <span id="toast-message"></span>
-    </div>
+      <!-- Toast Notification -->
+      <div
+        id="toast"
+        class="toast fixed bottom-5 right-5 bg-gray-800 text-white py-3 px-5 rounded-lg shadow-lg flex items-center space-x-3 z-50"
+      >
+        <i class="fas fa-check-circle text-green-400"></i>
+        <span id="toast-message"></span>
+      </div>
 
-    <script src="assets/js/contacts.js"></script>
-  </body>
-</html>
+      <script src="assets/js/contacts.js"></script>
+    </body>
+  </html>


### PR DESCRIPTION
## Summary
- add centered modal with shaded backdrop for adding new contacts
- include required fields such as name, owner, type and source
- wire up JavaScript to open, close and submit the form with toast notification

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689330cbda388326a03ccf1976547ae9