### PR TITLE
Remove activity summary from contact details

### DIFF
--- a/contact_details.html
+++ b/contact_details.html
@@ -174,16 +174,12 @@
         <!-- Tabs Area (right) -->
         <div class="tabs-container">
             <div class="tabs-header">
-                <button class="tab-button active" data-tab="activity"><i class="fas fa-chart-line"></i> Podsumowanie aktywności</button>
-                <button class="tab-button" data-tab="notes"><i class="fas fa-sticky-note"></i> Notatki</button>
+                <button class="tab-button active" data-tab="notes"><i class="fas fa-sticky-note"></i> Notatki</button>
                 <button class="tab-button" data-tab="email"><i class="fas fa-envelope"></i> E-maile</button>
                 <button class="tab-button" data-tab="tasks"><i class="fas fa-tasks"></i> Zadania</button>
             </div>
             <div class="tab-content">
-                <div class="tab-pane active" id="activity">
-                    <!-- Activity summary and items as before -->
-                </div>
-                <div class="tab-pane" id="notes">
+                <div class="tab-pane active" id="notes">
                     <div class="mb-4 flex space-x-2">
                         <input id="new-note-input" type="text" placeholder="Dodaj notatkę" class="flex-1 border rounded px-3 py-2" />
                         <button id="add-note-btn" class="brand-accent px-4 py-2 rounded text-white">Dodaj notatkę</button>


### PR DESCRIPTION
## Summary
- remove "Podsumowanie aktywności" tab from the contact card and make notes the default tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893378776c8832684ae6e8f616aac63