### PR TITLE
Remove summary tab from offer details

### DIFF
--- a/offer_details.html
+++ b/offer_details.html
@@ -182,16 +182,12 @@
         <!-- Tabs Area (right) -->
         <div class="tabs-container">
             <div class="tabs-header">
-                <button class="tab-button active" data-tab="summary"><i class="fas fa-chart-line"></i> Podsumowanie</button>
-                <button class="tab-button" data-tab="notes"><i class="fas fa-sticky-note"></i> Notatki</button>
+                <button class="tab-button active" data-tab="notes"><i class="fas fa-sticky-note"></i> Notatki</button>
                 <button class="tab-button" data-tab="tasks"><i class="fas fa-tasks"></i> Zadania</button>
                 <button class="tab-button" data-tab="rfq"><i class="fas fa-file-alt"></i> Zapytania ofertowe</button>
             </div>
             <div class="tab-content">
-                <div class="tab-pane active" id="summary">
-                    <!-- Podsumowanie content -->
-                </div>
-                <div class="tab-pane" id="notes">
+                <div class="tab-pane active" id="notes">
                     <!-- Notes content -->
                 </div>
                 <div class="tab-pane" id="tasks">


### PR DESCRIPTION
## Summary
- drop unused "Podsumowanie" tab from offer details view
- set "Notatki" as the default active tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933c470be08326819e125d7f2e4804