### PR TITLE
feat: add notes/tasks to offer card and show add-offer modal

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -620,24 +620,22 @@
 
         }
 
-        // Add event listener for "Nowy deal/kontakt" button in the header
-        if (addNewButton)
+        // Add event listener for header button (np. "Nowa oferta")
+        if (addNewButton) {
           addNewButton.addEventListener("click", () => {
             if (addOfferModal) {
               addOfferModal.classList.remove("hidden");
-            } else if (kanbanView.classList.contains("hidden")) {
-              // If contacts view is active
+            } else if (kanbanView && kanbanView.classList.contains("hidden")) {
               showToast(
                 "Funkcja dodawania nowego kontaktu będzie dostępna wkrótce!",
               );
             } else {
-              // If kanban view is active
               showToast(
                 "Funkcja dodawania nowego dealu będzie dostępna wkrótce!",
               );
             }
-            // In a real app, this would open a form to create a new deal/contact.
           });
+        }
 
         if (cancelAddOffer && addOfferModal) {
           cancelAddOffer.addEventListener("click", () => {

--- a/assets/js/offer_details.js
+++ b/assets/js/offer_details.js
@@ -19,6 +19,128 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   });
 
+  const addNoteBtn = document.getElementById('add-note-btn');
+  const newNoteInput = document.getElementById('new-note-input');
+  const notesList = document.getElementById('notes-list');
+
+  if (addNoteBtn && newNoteInput && notesList) {
+    addNoteBtn.addEventListener('click', () => {
+      const text = newNoteInput.value.trim();
+      if (!text) return;
+      const date = new Date().toLocaleDateString('pl-PL');
+      const note = document.createElement('div');
+      note.className = 'border p-3 rounded';
+      note.innerHTML = `<div class="text-sm text-gray-600 mb-1">Dawid Śmietański – ${date}</div><div>${text}</div>`;
+      notesList.prepend(note);
+      newNoteInput.value = '';
+    });
+  }
+
+  const addTaskBtn = document.getElementById('add-task-btn');
+  const newTaskTitle = document.getElementById('new-task-title');
+  const newTaskContent = document.getElementById('new-task-content');
+  const newTaskUser = document.getElementById('new-task-user');
+  const newTaskDate = document.getElementById('new-task-date');
+  const tasksList = document.getElementById('tasks-list');
+
+  if (addTaskBtn && newTaskTitle && newTaskContent && newTaskUser && newTaskDate && tasksList) {
+    const crmUsers = ['Dawid Śmietański', 'Magda Cieciorowska', 'Damian Zawadzki', 'Łukasz Zawadzki', 'Igor Dąbrowski', 'Klaudia Brożyna'];
+    crmUsers.forEach(user => {
+      const opt = document.createElement('option');
+      opt.value = user;
+      opt.textContent = user;
+      newTaskUser.appendChild(opt);
+    });
+
+    let tasks = JSON.parse(localStorage.getItem('offerTasks')) || [
+      { title: 'Przygotować ofertę', content: '', user: 'Łukasz Zawadzki', dueDate: '2024-06-01', completed: false },
+      { title: 'Wysłać prezentację', content: '', user: 'Igor Dąbrowski', dueDate: '2024-04-01', completed: false },
+      { title: 'Oddzwonić do klienta', content: '', user: 'Klaudia Brożyna', dueDate: '2024-03-20', completed: true }
+    ];
+
+    function saveTasks() {
+      localStorage.setItem('offerTasks', JSON.stringify(tasks));
+    }
+
+    function getStatus(task) {
+      const today = new Date().setHours(0, 0, 0, 0);
+      const due = new Date(task.dueDate).setHours(0, 0, 0, 0);
+      if (task.completed) return { text: 'wykonane', color: 'bg-green-100 text-green-800' };
+      if (due < today) return { text: 'przeterminowane', color: 'bg-red-100 text-red-800' };
+      return { text: 'oczekujące', color: 'bg-yellow-100 text-yellow-800' };
+    }
+
+    function renderTasks() {
+      tasksList.innerHTML = '';
+      tasks.forEach((task, index) => {
+        const status = getStatus(task);
+        const wrapper = document.createElement('div');
+        wrapper.className = 'border p-3 rounded flex justify-between items-start';
+        wrapper.innerHTML = `
+          <div>
+            <div class="font-medium">${task.title || task.text}</div>
+            <div class="text-sm text-gray-600">${task.user ? task.user + ' – ' : ''}Do ${new Date(task.dueDate).toLocaleDateString('pl-PL')}</div>
+            ${task.content ? `<div class="text-sm mt-1">${task.content}</div>` : ''}
+          </div>
+          <div class="flex items-center space-x-2">
+            <span class="px-2 py-1 rounded text-xs ${status.color}">${status.text}</span>
+            ${task.completed ? '' : `<button data-index="${index}" class="complete-task-btn bg-green-500 text-white text-xs px-2 py-1 rounded">Zakończ</button>`}
+            <button data-index="${index}" class="delete-task-btn bg-red-500 text-white text-xs px-2 py-1 rounded">Usuń</button>
+          </div>
+        `;
+        tasksList.appendChild(wrapper);
+      });
+
+      document.querySelectorAll('.complete-task-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const idx = btn.getAttribute('data-index');
+          tasks[idx].completed = true;
+          saveTasks();
+          renderTasks();
+        });
+      });
+
+      document.querySelectorAll('.delete-task-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const idx = btn.getAttribute('data-index');
+          tasks.splice(idx, 1);
+          saveTasks();
+          renderTasks();
+        });
+      });
+    }
+
+    addTaskBtn.addEventListener('click', () => {
+      const title = newTaskTitle.value.trim();
+      const content = newTaskContent.value.trim();
+      const user = newTaskUser.value;
+      const date = newTaskDate.value;
+      if (!title || !user || !date) return;
+      tasks.push({ title, content, user, dueDate: date, completed: false });
+      saveTasks();
+      renderTasks();
+      newTaskTitle.value = '';
+      newTaskContent.value = '';
+      newTaskDate.value = '';
+      newTaskUser.selectedIndex = 0;
+    });
+
+    function checkNotifications() {
+      const today = new Date().toISOString().split('T')[0];
+      tasks.forEach(task => {
+        if (!task.completed && task.dueDate === today && !task.notified) {
+          alert(`Masz zadanie na dziś: ${task.title || task.text}`);
+          task.notified = true;
+        }
+      });
+      saveTasks();
+    }
+
+    renderTasks();
+    checkNotifications();
+    setInterval(checkNotifications, 60000);
+  }
+
   function initRFQ() {
     const loadBtn = document.getElementById('load-subs');
     if (!loadBtn) return;

--- a/offer_details.html
+++ b/offer_details.html
@@ -188,10 +188,36 @@
             </div>
             <div class="tab-content">
                 <div class="tab-pane active" id="notes">
-                    <!-- Notes content -->
+                    <div class="mb-4 flex space-x-2">
+                        <input id="new-note-input" type="text" placeholder="Dodaj notatkę" class="flex-1 border rounded px-3 py-2" />
+                        <button id="add-note-btn" class="brand-accent px-4 py-2 rounded text-white">Dodaj notatkę</button>
+                    </div>
+                    <div id="notes-list" class="space-y-4">
+                        <div class="border p-3 rounded">
+                            <div class="text-sm text-gray-600 mb-1">Magda Cieciorowska – 01.04.2024</div>
+                            <div>Rozmowa telefoniczna z klientem w sprawie nowej oferty.</div>
+                        </div>
+                        <div class="border p-3 rounded">
+                            <div class="text-sm text-gray-600 mb-1">Damian Zawadzki – 20.03.2024</div>
+                            <div>Wysłał zapytanie o możliwości integracji.</div>
+                        </div>
+                        <div class="border p-3 rounded">
+                            <div class="text-sm text-gray-600 mb-1">Łukasz Zawadzki – 15.03.2024</div>
+                            <div>Dodano nową ofertę do bazy CRM.</div>
+                        </div>
+                    </div>
                 </div>
                 <div class="tab-pane" id="tasks">
-                    <!-- Tasks content -->
+                    <div class="mb-4 space-y-2">
+                        <input id="new-task-title" type="text" placeholder="Temat zadania" class="w-full border rounded px-3 py-2" />
+                        <input id="new-task-content" type="text" placeholder="Treść zadania" class="w-full border rounded px-3 py-2" />
+                        <div class="flex space-x-2">
+                            <select id="new-task-user" class="border rounded px-3 py-2 flex-1"></select>
+                            <input id="new-task-date" type="date" class="border rounded px-3 py-2" />
+                            <button id="add-task-btn" class="brand-accent px-4 py-2 rounded text-white">Zapisz</button>
+                        </div>
+                    </div>
+                    <div id="tasks-list" class="space-y-4"></div>
                 </div>
                 <div class="tab-pane" id="rfq">
                     <div id="rfq-tab">


### PR DESCRIPTION
## Summary
- replicate Notes and Tasks tab UI/behavior from contact cards on offer details
- hook up the 'Nowa oferta' header button to display the add-offer modal

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933e6c145c8326a5f0392ac02284a8