### PR TITLE
Add manual email entry in messages tab

### DIFF
--- a/assets/js/offer_details.js
+++ b/assets/js/offer_details.js
@@ -55,16 +55,22 @@ document.addEventListener('DOMContentLoaded', function () {
         }
       ];
 
-      messages.forEach(msg => {
+      function renderMessage(msg) {
         const wrapper = document.createElement('div');
         wrapper.className = 'border rounded';
 
         const header = document.createElement('div');
         header.className = 'p-3 flex justify-between items-center cursor-pointer';
+        const directionText =
+          msg.direction === 'incoming'
+            ? 'Odebrano'
+            : msg.direction === 'manual'
+            ? 'Dodano'
+            : 'Wysłano';
         header.innerHTML = `
           <div>
             <div class="font-medium">${msg.subject}</div>
-            <div class="text-sm text-gray-600">${msg.direction === 'incoming' ? 'Odebrano' : 'Wysłano'} ${msg.date}</div>
+            <div class="text-sm text-gray-600">${directionText} ${msg.date}</div>
           </div>
           <span class="bg-gray-200 text-gray-800 px-2 py-1 rounded text-xs">${msg.user}</span>
         `;
@@ -80,7 +86,42 @@ document.addEventListener('DOMContentLoaded', function () {
         wrapper.appendChild(header);
         wrapper.appendChild(body);
         messagesList.appendChild(wrapper);
-      });
+      }
+
+      messages.forEach(renderMessage);
+
+      const addManualBtn = document.getElementById('add-manual-message-btn');
+      const manualModal = document.getElementById('manual-message-modal');
+      const manualInput = document.getElementById('manual-message-input');
+      const manualCancel = document.getElementById('cancel-manual-message');
+      const manualSave = document.getElementById('save-manual-message');
+
+      if (addManualBtn && manualModal && manualInput && manualCancel && manualSave) {
+        addManualBtn.addEventListener('click', () => {
+          manualModal.style.display = 'flex';
+        });
+
+        manualCancel.addEventListener('click', () => {
+          manualModal.style.display = 'none';
+          manualInput.value = '';
+        });
+
+        manualSave.addEventListener('click', () => {
+          const text = manualInput.value.trim();
+          if (!text) return;
+          const lines = text.split('\n');
+          const subject = lines[0] || 'Wiadomość';
+          renderMessage({
+            direction: 'manual',
+            user: 'Użytkownik',
+            date: new Date().toLocaleDateString('pl-PL'),
+            subject,
+            body: text
+          });
+          manualInput.value = '';
+          manualModal.style.display = 'none';
+        });
+      }
     }
 
     const addTaskBtn = document.getElementById('add-task-btn');

--- a/offer_details.html
+++ b/offer_details.html
@@ -212,7 +212,24 @@
                     </div>
                 </div>
                 <div class="tab-pane" id="messages">
+                    <div class="mb-4">
+                        <button id="add-manual-message-btn" class="brand-accent px-4 py-2 rounded text-white">Dodaj ręcznie wiadomość email</button>
+                    </div>
                     <div id="messages-list" class="space-y-4"></div>
+
+                    <!-- Modal dodawania wiadomości -->
+                    <div id="manual-message-modal" class="modal-overlay">
+                        <div class="modal">
+                            <div class="modal-header">Dodaj wiadomość e-mail</div>
+                            <div class="modal-body">
+                                <textarea id="manual-message-input" class="w-full border rounded p-2" rows="10" placeholder="Wklej treść wiadomości"></textarea>
+                            </div>
+                            <div class="modal-footer">
+                                <button id="cancel-manual-message">Anuluj</button>
+                                <button id="save-manual-message">Zapisz</button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="tab-pane" id="tasks">
                     <div class="mb-4 space-y-2">


### PR DESCRIPTION
## Summary
- add manual email entry button and modal in messages tab
- support saving manually entered emails to message list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68935bc575fc832681da66c75d5b2568