### PR TITLE
Display added offer details

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -584,15 +584,24 @@
 
         // --- EVENT LISTENERS & NAVIGATION ---
         function addDragAndDropListeners() {
-          // Temporary: open first deal details page on click
-          const firstCard = document.getElementById("deal-1");
-          if (firstCard) {
-            firstCard.addEventListener("click", () => {
-              window.location.href = "offer_details.html";
-            });
-          }
-
           document.querySelectorAll('[draggable="true"]').forEach((card) => {
+            card.addEventListener("click", () => {
+              const id = parseInt(card.dataset.dealId);
+              const selected = deals.find((d) => d.id === id);
+              if (selected) {
+                const stageObj = stages.find((s) => s.id === selected.stage);
+                const selectedData = {
+                  ...selected,
+                  stageName: stageObj ? stageObj.name : "",
+                };
+                localStorage.setItem(
+                  "selectedOffer",
+                  JSON.stringify(selectedData),
+                );
+                window.location.href = "offer_details.html";
+              }
+            });
+
             card.addEventListener("dragstart", (e) => {
               e.dataTransfer.setData("text/plain", card.id);
               // Add a class to the dragged card for visual feedback
@@ -693,6 +702,35 @@
         if (addOfferForm) {
           addOfferForm.addEventListener("submit", (e) => {
             e.preventDefault();
+            const newDeal = {
+              id: Date.now(),
+              stage: document.getElementById("offer-stage").value,
+              projectName: document.getElementById("offer-name").value,
+              company: document.getElementById("offer-company").value,
+              roofTech:
+                document.getElementById("offer-roof-tech").value || "Inne",
+              areaM2:
+                parseFloat(document.getElementById("offer-area").value) || 0,
+              valueNet:
+                parseFloat(document.getElementById("offer-value").value) || 0,
+              probability: 0,
+              openDate: new Date().toISOString().split("T")[0],
+              expectedClose: "",
+              margin: 20,
+              startDate: document.getElementById("offer-start-date").value,
+              location: document.getElementById("offer-city").value,
+              investorType: document.getElementById("offer-investor-type").value,
+              objectType: document.getElementById("offer-object-type").value,
+              structureType:
+                document.getElementById("offer-structure-type").value,
+              insulationType:
+                document.getElementById("offer-insulation-type").value,
+              acquisitionSource:
+                document.getElementById("offer-acquisition-source").value,
+              contact: document.getElementById("offer-contact").value,
+            };
+            deals.push(newDeal);
+            renderBoard();
             addOfferModal.classList.add("hidden");
             addOfferForm.reset();
             showToast("Oferta została dodana");

--- a/assets/js/offer_info.js
+++ b/assets/js/offer_info.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const data = JSON.parse(localStorage.getItem('selectedOffer'));
+  if (!data) return;
+
+  const formatDate = (str) => {
+    if (!str) return '';
+    const [y, m, d] = str.split('-');
+    return `${d}.${m}.${y}`;
+  };
+
+  const setText = (id, text) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = text || '';
+  };
+
+  setText('detail-name', data.projectName);
+  setText('detail-status', data.stageName);
+  setText('detail-company', data.company);
+  setText('detail-value', `${(data.valueNet || 0).toLocaleString('pl-PL')} PLN`);
+  setText('detail-margin', `${data.margin || 0}%`);
+  setText('detail-start', formatDate(data.startDate));
+  setText('detail-city', data.location);
+  setText('detail-investor', data.investorType);
+  setText('detail-owner', data.contact);
+  setText('detail-added', formatDate(data.openDate));
+});

--- a/offer_details.html
+++ b/offer_details.html
@@ -155,26 +155,26 @@
                 </a>
             </div>
             <div class="offer-info-header">
-                <div class="offer-avatar">O1</div>
-                <h3>Nowy dach dla Biedronki</h3>
+                <div class="offer-avatar" id="detail-avatar">O1</div>
+                <h3 id="detail-name">Nowy dach dla Biedronki</h3>
             </div>
             <div class="info-group">
                 <div class="info-group-title">Informacje podstawowe</div>
-                <div class="info-item"><span class="info-label">Status:</span><span class="offer-status-badge">Analiza techniczna</span></div>
-                <div class="info-item"><span class="info-label">Właściciel:</span><span class="info-value">Jan Nowak</span></div>
-                <div class="info-item"><span class="info-label">Dodano:</span><span class="info-value">15.03.2024</span></div>
+                <div class="info-item"><span class="info-label">Status:</span><span id="detail-status" class="offer-status-badge">Analiza techniczna</span></div>
+                <div class="info-item"><span class="info-label">Właściciel:</span><span id="detail-owner" class="info-value">Jan Nowak</span></div>
+                <div class="info-item"><span class="info-label">Dodano:</span><span id="detail-added" class="info-value">15.03.2024</span></div>
             </div>
             <div class="info-group">
                 <div class="info-group-title">Szczegóły oferty</div>
-                <div class="info-item"><span class="info-label">Firma:</span><span class="info-value">Jeronimo Martins Polska S.A.</span></div>
-                <div class="info-item"><span class="info-label">Wartość netto:</span><span class="info-value">750 000 PLN</span></div>
-                <div class="info-item"><span class="info-label">Szacowana marża:</span><span class="info-value">20%</span></div>
-                <div class="info-item"><span class="info-label">Planowane rozpoczęcie:</span><span class="info-value">01.09.2025</span></div>
+                <div class="info-item"><span class="info-label">Firma:</span><span id="detail-company" class="info-value">Jeronimo Martins Polska S.A.</span></div>
+                <div class="info-item"><span class="info-label">Wartość netto:</span><span id="detail-value" class="info-value">750 000 PLN</span></div>
+                <div class="info-item"><span class="info-label">Szacowana marża:</span><span id="detail-margin" class="info-value">20%</span></div>
+                <div class="info-item"><span class="info-label">Planowane rozpoczęcie:</span><span id="detail-start" class="info-value">01.09.2025</span></div>
             </div>
             <div class="info-group">
                 <div class="info-group-title">Lokalizacja</div>
-                <div class="info-item"><span class="info-label">Miasto:</span><span class="info-value">Warszawa</span></div>
-                <div class="info-item"><span class="info-label">Typ inwestora:</span><span class="info-value">Komercyjny</span></div>
+                <div class="info-item"><span class="info-label">Miasto:</span><span id="detail-city" class="info-value">Warszawa</span></div>
+                <div class="info-item"><span class="info-label">Typ inwestora:</span><span id="detail-investor" class="info-value">Komercyjny</span></div>
             </div>
             <div class="offer-info-footer">
                 <button class="edit-offer-btn"><i class="fas fa-edit"></i> Edytuj ofertę</button>
@@ -303,6 +303,7 @@
             </div>
         </div>
 </div>
+<script src="assets/js/offer_info.js"></script>
 <script src="assets/js/offer_details.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create new deals from the add-offer form and render them on the board
- allow clicking any deal to store its data in localStorage and open the offer details page
- load offer data from localStorage to populate the "Szczegóły oferty" section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894575df3b483269d58af5af7d5fab3