### PR TITLE
Integrate Supabase for contacts

### DIFF
--- a/assets/js/contacts.js
+++ b/assets/js/contacts.js
@@ -1,207 +1,12 @@
 document.addEventListener("DOMContentLoaded", function () {
-  const contacts = [
-    {
-      id: 1,
-      name: "Adam Nowak",
-      company: "Jeronimo Martins Polska S.A.",
-      phone: "501 123 456",
-      email: "a.nowak@jm.pl",
-      address: "ul. Żniwna 5, 62-025 Kostrzyn",
-      type: "Klient",
-      lastActivity: "2025-07-01",
-    },
-    {
-      id: 2,
-      name: "Ewa Kowalska",
-      company: "Panattoni Development Europe",
-      phone: "602 234 567",
-      email: "ewa.kowalska@panattoni.com",
-      address: "Plac Europejski 1, 00-844 Warszawa",
-      type: "Klient",
-      lastActivity: "2025-06-28",
-    },
-    {
-      id: 3,
-      name: "Piotr Wiśniewski",
-      company: "Dachy i Fasady Sp. z o.o.",
-      phone: "703 345 678",
-      email: "piotr@dachy-fasady.pl",
-      address: "ul. Przemysłowa 10, 95-100 Zgierz",
-      type: "Podwykonawca",
-      lastActivity: "2025-06-25",
-    },
-    {
-      id: 4,
-      name: "Katarzyna Dąbrowska",
-      company: "Bud-Mat",
-      phone: "804 456 789",
-      email: "k.dabrowska@budmat.com",
-      address: "ul. Otolińska 25, 09-407 Płock",
-      type: "Dostawca",
-      lastActivity: "2025-07-02",
-    },
-    {
-      id: 5,
-      name: "Tomasz Zieliński",
-      company: "Inwestor Prywatny",
-      phone: "505 567 890",
-      email: "t.zielinski@poczta.pl",
-      address: "ul. Piotrkowska 1, 90-001 Łódź",
-      type: "Potencjalny klient",
-      lastActivity: "2025-06-30",
-    },
-    {
-      id: 6,
-      name: "Marek Jankowski",
-      company: "Global Build",
-      phone: "606 678 901",
-      email: "m.jankowski@globalbuild.com",
-      address: "ul. Wrocławska 54, 50-001 Wrocław",
-      type: "Potencjalny klient",
-      lastActivity: "2025-05-15",
-    },
-    {
-      id: 7,
-      name: "Agnieszka Maj",
-      company: "BuildIt",
-      phone: "517 234 111",
-      email: "a.maj@buildit.pl",
-      address: "ul. Lipowa 3, 00-201 Warszawa",
-      type: "Klient",
-      lastActivity: "2025-06-22",
-    },
-    {
-      id: 8,
-      name: "Paweł Stępień",
-      company: "TechSolutions",
-      phone: "523 335 222",
-      email: "pawel.stepien@techsol.com",
-      address: "ul. Ogrodowa 5, 01-000 Warszawa",
-      type: "Klient",
-      lastActivity: "2025-07-03",
-    },
-    {
-      id: 9,
-      name: "Julia Bąk",
-      company: "Green House",
-      phone: "534 445 333",
-      email: "julia.bak@greenhouse.pl",
-      address: "ul. Leśna 7, 05-800 Pruszków",
-      type: "Dostawca",
-      lastActivity: "2025-06-18",
-    },
-    {
-      id: 10,
-      name: "Krzysztof Pawlak",
-      company: "KP Projekt",
-      phone: "545 556 444",
-      email: "k.pawlak@kpprojekt.pl",
-      address: "ul. Słoneczna 12, 20-001 Lublin",
-      type: "Podwykonawca",
-      lastActivity: "2025-06-12",
-    },
-    {
-      id: 11,
-      name: "Monika Król",
-      company: "FastTrans",
-      phone: "556 667 555",
-      email: "monika.krol@fasttrans.pl",
-      address: "ul. Nowa 8, 40-100 Katowice",
-      type: "Potencjalny klient",
-      lastActivity: "2025-05-30",
-    },
-    {
-      id: 12,
-      name: "Sebastian Lis",
-      company: "InwestBud",
-      phone: "567 778 666",
-      email: "s.lis@inwestbud.pl",
-      address: "ul. Polna 4, 30-002 Kraków",
-      type: "Klient",
-      lastActivity: "2025-06-08",
-    },
-    {
-      id: 13,
-      name: "Natalia Górska",
-      company: "DesignPro",
-      phone: "578 889 777",
-      email: "natalia.gorska@designpro.pl",
-      address: "ul. Spacerowa 9, 80-001 Gdańsk",
-      type: "Klient",
-      lastActivity: "2025-06-01",
-    },
-    {
-      id: 14,
-      name: "Robert Wójcik",
-      company: "RW Consulting",
-      phone: "589 990 888",
-      email: "robert.wojcik@rwconsult.pl",
-      address: "ul. Dworcowa 2, 35-001 Rzeszów",
-      type: "Potencjalny klient",
-      lastActivity: "2025-05-20",
-    },
-    {
-      id: 15,
-      name: "Aneta Piotrowska",
-      company: "AP Steel",
-      phone: "600 101 999",
-      email: "a.piotrowska@apsteel.pl",
-      address: "ul. Fabryczna 20, 15-001 Białystok",
-      type: "Dostawca",
-      lastActivity: "2025-04-30",
-    },
-    {
-      id: 16,
-      name: "Michał Sawicki",
-      company: "Sawicki Sp. z o.o.",
-      phone: "611 212 000",
-      email: "m.sawicki@sawicki.pl",
-      address: "ul. Kolejowa 18, 70-100 Szczecin",
-      type: "Klient",
-      lastActivity: "2025-05-10",
-    },
-    {
-      id: 17,
-      name: "Karolina Kaczmarek",
-      company: "Kaczmarek Design",
-      phone: "622 323 111",
-      email: "karolina@kdesign.pl",
-      address: "ul. Nadmorska 2, 81-001 Gdynia",
-      type: "Potencjalny klient",
-      lastActivity: "2025-06-05",
-    },
-    {
-      id: 18,
-      name: "Wojciech Pietrzak",
-      company: "WP Invest",
-      phone: "633 434 222",
-      email: "w.pietrzak@wpinvest.pl",
-      address: "ul. Rynek 1, 32-000 Olkusz",
-      type: "Klient",
-      lastActivity: "2025-07-05",
-    },
-    {
-      id: 19,
-      name: "Renata Szymańska",
-      company: "SzymBud",
-      phone: "644 545 333",
-      email: "renata@szymbud.pl",
-      address: "ul. Jasna 3, 60-125 Poznań",
-      type: "Podwykonawca",
-      lastActivity: "2025-05-18",
-    },
-    {
-      id: 20,
-      name: "Łukasz Baran",
-      company: "Baran Development",
-      phone: "655 656 444",
-      email: "lukasz.baran@barandev.pl",
-      address: "ul. Długa 10, 44-100 Gliwice",
-      type: "Klient",
-      lastActivity: "2025-06-27",
-    },
-  ];
+  const supabaseUrl = "https://your-project.supabase.co";
+  const supabaseAnonKey = "public-anon-key";
+  const supabaseClient = window.supabase.createClient(
+    supabaseUrl,
+    supabaseAnonKey
+  );
 
+  let contacts = [];
   const contactsPerPage = 8;
   let currentPage = 1;
 
@@ -218,6 +23,35 @@ document.addEventListener("DOMContentLoaded", function () {
     toastMessage.textContent = message;
     toast.classList.add("show");
     setTimeout(() => toast.classList.remove("show"), 3000);
+  }
+
+  async function loadContacts() {
+    const { data, error } = await supabaseClient
+      .from("contacts")
+      .select(
+        "id, first_name, last_name, phone, email, type, last_activity_date, company:companies(name, address, city)"
+      )
+      .order("last_activity_date", { ascending: false });
+
+    if (error) {
+      console.error("Błąd pobierania kontaktów:", error);
+      return;
+    }
+
+    contacts = data.map((c) => ({
+      id: c.id,
+      name: `${c.first_name} ${c.last_name}`,
+      company: c.company?.name || "",
+      address: [c.company?.address, c.company?.city]
+        .filter(Boolean)
+        .join(", "),
+      phone: c.phone,
+      email: c.email,
+      type: c.type,
+      lastActivity: c.last_activity_date,
+    }));
+
+    renderContacts();
   }
 
   function renderContacts(page = currentPage) {
@@ -256,7 +90,7 @@ document.addEventListener("DOMContentLoaded", function () {
           </span>
         </td>
         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-          ${contact.lastActivity}
+          ${contact.lastActivity || ""}
         </td>`;
       fragment.appendChild(row);
     });
@@ -313,13 +147,51 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   if (form) {
-    form.addEventListener("submit", (e) => {
+    form.addEventListener("submit", async (e) => {
       e.preventDefault();
+
+      const fullName = document.getElementById("contact-name").value.trim();
+      const [firstName, ...rest] = fullName.split(" ");
+      const lastName = rest.join(" ");
+
+      const companyData = {
+        name: document.getElementById("contact-company").value.trim() || null,
+        nip: document.getElementById("contact-nip").value.trim() || null,
+        address: document.getElementById("contact-address").value.trim() || null,
+        city: document.getElementById("contact-city").value.trim() || null,
+        voivodeship:
+          document.getElementById("contact-voivodeship").value.trim() || null,
+        website: document.getElementById("contact-website").value.trim() || null,
+      };
+
+      const contactData = {
+        first_name: firstName || "",
+        last_name: lastName || "",
+        phone: document.getElementById("contact-phone").value.trim() || null,
+        email: document.getElementById("contact-email").value.trim() || null,
+        type: document.getElementById("contact-type").value,
+        source: document.getElementById("contact-source").value,
+        last_activity_date: new Date().toISOString().split("T")[0],
+      };
+
+      const { error } = await supabaseClient.rpc("add_contact_with_company", {
+        company_data: companyData,
+        contact_data: contactData,
+      });
+
+      if (error) {
+        console.error("Błąd dodawania kontaktu:", error);
+        showToast("Wystąpił błąd podczas zapisywania");
+        return;
+      }
+
+      await loadContacts();
       modal.classList.add("hidden");
       form.reset();
       showToast("Kontakt został dodany");
     });
   }
 
-  renderContacts();
+  loadContacts();
 });
+

--- a/contacts.html
+++ b/contacts.html
@@ -399,6 +399,7 @@
       <span id="toast-message"></span>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="assets/js/contacts.js"></script>
   </body>
 </html>

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,74 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.companies (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  nip text,
+  address text,
+  city text,
+  voivodeship text,
+  website text
+);
+
+create table if not exists public.contacts (
+  id uuid primary key default gen_random_uuid(),
+  first_name text not null,
+  last_name text not null,
+  phone text,
+  email text,
+  type text,
+  source text,
+  last_activity_date date,
+  company_id uuid references public.companies(id)
+);
+
+create or replace function public.add_contact_with_company(
+  company_data jsonb,
+  contact_data jsonb
+)
+returns uuid
+language plpgsql
+as $$
+declare
+  new_company_id uuid;
+  new_contact_id uuid;
+begin
+  if company_data ? 'name' and company_data->>'name' is not null and company_data->>'name' <> '' then
+    insert into public.companies(name, nip, address, city, voivodeship, website)
+    values (
+      company_data->>'name',
+      company_data->>'nip',
+      company_data->>'address',
+      company_data->>'city',
+      company_data->>'voivodeship',
+      company_data->>'website'
+    )
+    returning id into new_company_id;
+  end if;
+
+  insert into public.contacts(
+    first_name,
+    last_name,
+    phone,
+    email,
+    type,
+    source,
+    last_activity_date,
+    company_id
+  )
+  values (
+    contact_data->>'first_name',
+    contact_data->>'last_name',
+    contact_data->>'phone',
+    contact_data->>'email',
+    contact_data->>'type',
+    contact_data->>'source',
+    (contact_data->>'last_activity_date')::date,
+    new_company_id
+  )
+  returning id into new_contact_id;
+
+  return new_contact_id;
+end;
+$$;
+


### PR DESCRIPTION
## Summary
- add Supabase schema and helper function to insert contact with company atomically
- fetch contacts from Supabase instead of static list
- save new contacts and companies to Supabase in a transaction and wire up Supabase client in UI

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68945bc517388326addb0a9ac92d299e