### PR TITLE
feat: add notes and messages persistence

### DIFF
--- a/assets/js/contact_details.js
+++ b/assets/js/contact_details.js
@@ -31,6 +31,19 @@ document.addEventListener('DOMContentLoaded', () => {
       note.innerHTML = `<div class="text-sm text-gray-600 mb-1">Dawid Śmietański – ${date}</div><div>${text}</div>`;
       notesList.prepend(note);
       newNoteInput.value = '';
+
+      // Persist note
+      const entityId = new URLSearchParams(window.location.search).get('id');
+      const userId = window.currentUserId || null;
+      if (window.supabaseClient && entityId && userId) {
+        window.supabaseClient.from('notes').insert({
+          id: crypto.randomUUID(),
+          entity_type: 'contact',
+          entity_id: entityId,
+          user_id: userId,
+          content: text
+        });
+      }
     });
   }
 

--- a/assets/js/offer_details.js
+++ b/assets/js/offer_details.js
@@ -33,6 +33,19 @@ document.addEventListener('DOMContentLoaded', function () {
       note.innerHTML = `<div class="text-sm text-gray-600 mb-1">Dawid Śmietański – ${date}</div><div>${text}</div>`;
       notesList.prepend(note);
       newNoteInput.value = '';
+
+      // Persist note
+      const entityId = new URLSearchParams(window.location.search).get('id');
+      const userId = window.currentUserId || null;
+      if (window.supabaseClient && entityId && userId) {
+        window.supabaseClient.from('notes').insert({
+          id: crypto.randomUUID(),
+          entity_type: 'offer',
+          entity_id: entityId,
+          user_id: userId,
+          content: text
+        });
+      }
     });
     }
 
@@ -120,6 +133,23 @@ document.addEventListener('DOMContentLoaded', function () {
           });
           manualInput.value = '';
           manualModal.style.display = 'none';
+
+          // Persist manual message
+          const entityId = new URLSearchParams(window.location.search).get('id');
+          const userId = window.currentUserId || null;
+          if (window.supabaseClient && entityId && userId) {
+            window.supabaseClient.from('messages').insert({
+              id: crypto.randomUUID(),
+              entity_type: 'offer',
+              entity_id: entityId,
+              direction: 'manual',
+              user_id: userId,
+              subject,
+              body: text,
+              sent_at: new Date().toISOString(),
+              status: 'manual'
+            });
+          }
         });
       }
     }

--- a/assets/js/supabaseClient.js
+++ b/assets/js/supabaseClient.js
@@ -1,0 +1,6 @@
+// Supabase client initialization
+// Replace the URL and key with your project's configuration
+const SUPABASE_URL = window._env?.SUPABASE_URL || 'https://your-project.supabase.co';
+const SUPABASE_ANON_KEY = window._env?.SUPABASE_ANON_KEY || 'public-anon-key';
+
+window.supabaseClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/contact_details.html
+++ b/contact_details.html
@@ -219,6 +219,8 @@
             </div>
         </div>
     </div>
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<script src="assets/js/supabaseClient.js"></script>
 <script src="assets/js/contact_details.js"></script>
 </body>
 </html>

--- a/offer_details.html
+++ b/offer_details.html
@@ -304,6 +304,8 @@
         </div>
 </div>
 <script src="assets/js/offer_info.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<script src="assets/js/supabaseClient.js"></script>
 <script src="assets/js/offer_details.js"></script>
 </body>
 </html>

--- a/supabase/migrations/202405281200_create_notes_messages.sql
+++ b/supabase/migrations/202405281200_create_notes_messages.sql
@@ -1,0 +1,40 @@
+create table if not exists notes (
+  id uuid primary key,
+  entity_type text,
+  entity_id uuid,
+  user_id uuid references profiles(id),
+  content text,
+  created_at timestamptz default now()
+);
+
+create table if not exists messages (
+  id uuid primary key,
+  entity_type text,
+  entity_id uuid,
+  direction text,
+  user_id uuid references profiles(id),
+  subject text,
+  body text,
+  sent_at timestamptz,
+  status text
+);
+
+alter table messages enable row level security;
+
+create policy "Users can view related messages" on messages
+for select
+using (
+  auth.uid() = user_id
+  or exists (
+    select 1 from profiles p
+    where p.id = auth.uid()
+      and (
+        (messages.entity_type = 'company' and messages.entity_id = p.company_id) or
+        (messages.entity_type = 'project' and messages.entity_id = p.project_id)
+      )
+  )
+);
+
+create policy "Users can insert own messages" on messages
+for insert
+with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add Supabase migration for notes and messages tables with RLS
- wire front-end note and message creation to new tables
- include Supabase client setup and scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68945bcdad288326924cab747046c916