### PR TITLE
Fix login by allowing anon DB access

### DIFF
--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -42,7 +42,10 @@ document.addEventListener('DOMContentLoaded', function() {
             .eq('pass', password)
             .single();
 
-        if (error || !data) {
+        if (error) {
+            console.error('Login error:', error);
+            showToast(error.message || 'Nieprawidłowy login lub hasło.', 'error');
+        } else if (!data) {
             showToast('Nieprawidłowy login lub hasło.', 'error');
         } else {
             localStorage.setItem('currentUser', JSON.stringify(data));

--- a/supabase.sql
+++ b/supabase.sql
@@ -6,6 +6,21 @@ create table if not exists public.profiles (
   created_at timestamptz default now()
 );
 
+-- Allow anonymous access for simple login/registration flows
+alter table if exists public.profiles enable row level security;
+
+-- Permit anyone (anon) to read profile rows
+create policy "profiles_select_anon" on public.profiles
+for select
+to anon
+using (true);
+
+-- Permit anyone (anon) to create new profile rows
+create policy "profiles_insert_anon" on public.profiles
+for insert
+to anon
+with check (true);
+
 create table if not exists public.stages (
   id uuid primary key default gen_random_uuid(),
   name text unique not null,


### PR DESCRIPTION
## Summary
- allow anonymous select/insert on `profiles` table to enable login/registration
- surface detailed error messages during login

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68946dea7054832694b8ae560974a9a4