### PR TITLE
Handle multiple login records in Supabase query

### DIFF
--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -39,16 +39,16 @@ document.addEventListener('DOMContentLoaded', function() {
             .from('profiles')
             .select('id, full_name')
             .eq('login', username)
-            .eq('pass', password)
-            .single();
+            .eq('pass', password);
 
         if (error) {
             console.error('Login error:', error);
             showToast(error.message || 'Nieprawidłowy login lub hasło.', 'error');
-        } else if (!data) {
+        } else if (!data || data.length === 0) {
             showToast('Nieprawidłowy login lub hasło.', 'error');
         } else {
-            localStorage.setItem('currentUser', JSON.stringify(data));
+            const user = data[0];
+            localStorage.setItem('currentUser', JSON.stringify(user));
             showToast('Logowanie pomyślne!', 'success');
             setTimeout(() => {
                 window.location.href = 'index.html';


### PR DESCRIPTION
## Summary
- avoid `Cannot coerce the result to a single JSON object` by removing `.single()` from login query
- store the first matching user in local storage after verifying credentials

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6894706ebee08326835cf8f704059c58