### PR TITLE
Trim whitespace from login and registration inputs

### DIFF
--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -32,8 +32,8 @@ document.addEventListener('DOMContentLoaded', function() {
     loginForm.addEventListener('submit', async function(event) {
         event.preventDefault();
 
-        const username = usernameInput.value;
-        const password = passwordInput.value;
+        const username = usernameInput.value.trim();
+        const password = passwordInput.value.trim();
 
         const { data, error } = await window.supabaseClient
             .from('profiles')

--- a/assets/js/register.js
+++ b/assets/js/register.js
@@ -30,9 +30,9 @@ document.addEventListener('DOMContentLoaded', function() {
     registerForm.addEventListener('submit', async function(event) {
         event.preventDefault();
 
-        const login = loginInput.value;
-        const password = passwordInput.value;
-        const fullName = fullNameInput.value;
+        const login = loginInput.value.trim();
+        const password = passwordInput.value.trim();
+        const fullName = fullNameInput.value.trim();
 
         const { error } = await window.supabaseClient
             .from('profiles')


### PR DESCRIPTION
## Summary
- sanitize login credentials by trimming whitespace before authentication
- trim registration inputs to store clean values in `profiles`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68947485e924832684a9a1b5be5279ad