### PR TITLE
Improve error handling in authentication scripts

### DIFF
--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -43,7 +43,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
         if (error) {
             console.error('Login error:', error);
-            showToast(error.message || 'Nieprawidłowy login lub hasło.', 'error');
+            console.error('Status:', error.status);
+            console.error('Details:', error.details);
+            console.error('Hint:', error.hint);
+            if (error.status === 401 || error.status === 403) {
+                showToast('Brak uprawnień do wykonania tej operacji.', 'error');
+            } else {
+                showToast(error.message || 'Nieprawidłowy login lub hasło.', 'error');
+            }
         } else if (!data || data.length === 0) {
             showToast('Nieprawidłowy login lub hasło.', 'error');
         } else {

--- a/assets/js/register.js
+++ b/assets/js/register.js
@@ -39,7 +39,15 @@ document.addEventListener('DOMContentLoaded', function() {
             .insert({ full_name: fullName, login: login, pass: password });
 
         if (error) {
-            showToast(error.message, 'error');
+            console.error('Registration error:', error);
+            console.error('Status:', error.status);
+            console.error('Details:', error.details);
+            console.error('Hint:', error.hint);
+            if (error.status === 401 || error.status === 403) {
+                showToast('Brak uprawnień do wykonania tej operacji.', 'error');
+            } else {
+                showToast(error.message, 'error');
+            }
         } else {
             showToast('Rejestracja pomyślna!', 'success');
         }


### PR DESCRIPTION
## Summary
- log status, details and hint for Supabase errors in login and registration flows
- inform users about missing permissions on 401/403 responses

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68947486d2cc8326b5403dc0b736411e