### PR TITLE
Use Supabase Auth for user management

### DIFF
--- a/assets/js/register.js
+++ b/assets/js/register.js
@@ -34,9 +34,13 @@ document.addEventListener('DOMContentLoaded', function() {
         const password = passwordInput.value;
         const fullName = fullNameInput.value;
 
-        const { error } = await window.supabaseClient
-            .from('profiles')
-            .insert({ full_name: fullName, login: login, pass: password });
+        const { data, error } = await window.supabaseClient.auth.signUp({
+            email: login,
+            password: password,
+            options: {
+                data: { full_name: fullName }
+            }
+        });
 
         if (error) {
             showToast(error.message, 'error');

--- a/supabase.sql
+++ b/supabase.sql
@@ -1,25 +1,20 @@
 create table if not exists public.profiles (
-  id serial primary key,
+  id uuid primary key references auth.users(id) on delete cascade,
   full_name text,
-  login text unique not null,
-  pass text not null,
   created_at timestamptz default now()
 );
 
--- Allow anonymous access for simple login/registration flows
 alter table if exists public.profiles enable row level security;
 
--- Permit anyone (anon) to read profile rows
-create policy "profiles_select_anon" on public.profiles
+create policy "profiles_select_authenticated" on public.profiles
 for select
-to anon
+to authenticated
 using (true);
 
--- Permit anyone (anon) to create new profile rows
-create policy "profiles_insert_anon" on public.profiles
+create policy "profiles_insert_authenticated" on public.profiles
 for insert
-to anon
-with check (true);
+to authenticated
+with check (auth.uid() = id);
 
 create table if not exists public.stages (
   id uuid primary key default gen_random_uuid(),

--- a/supabase/files.sql
+++ b/supabase/files.sql
@@ -4,6 +4,6 @@ create table if not exists files (
   entity_id uuid,
   file_name text,
   file_url text,
-  uploaded_by integer references profiles(id),
+  uploaded_by uuid references profiles(id),
   uploaded_at timestamptz default now()
 );

--- a/supabase/profiles.sql
+++ b/supabase/profiles.sql
@@ -1,9 +1,7 @@
 -- Enable Auth module via Supabase dashboard or CLI before running this script.
 
 create table if not exists profiles (
-  id serial primary key,
+  id uuid primary key references auth.users(id) on delete cascade,
   full_name text,
-  login text unique not null,
-  pass text not null,
   created_at timestamptz default now()
 );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,10 +1,8 @@
 create extension if not exists "pgcrypto";
 
 create table if not exists public.profiles (
-  id serial primary key,
+  id uuid primary key references auth.users(id) on delete cascade,
   full_name text,
-  login text unique not null,
-  pass text not null,
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- Register users with `auth.signUp` instead of direct table inserts
- Sign in with `auth.signInWithPassword` and load the user's profile
- Align SQL schema with Supabase Auth-backed profiles

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894748789388326891893105b7df66a