### PR TITLE
feat: finalize Supabase login screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -1,0 +1,55 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const loginForm = document.getElementById('login-form');
+    const loginInput = document.getElementById('login');
+    const passwordInput = document.getElementById('password');
+    const loginToast = document.getElementById('login-toast');
+    const toastMessage = loginToast.querySelector('#toast-message');
+
+    function showToast(message, type = 'info') {
+        toastMessage.textContent = message;
+        loginToast.classList.remove('hidden');
+        loginToast.classList.add('show');
+
+        const icon = loginToast.querySelector('i');
+        icon.className = '';
+        if (type === 'success') {
+            icon.classList.add('fas', 'fa-check-circle', 'text-green-400');
+        } else if (type === 'error') {
+            icon.classList.add('fas', 'fa-times-circle', 'text-red-400');
+        } else {
+            icon.classList.add('fas', 'fa-info-circle', 'text-blue-400');
+        }
+
+        setTimeout(() => {
+            loginToast.classList.remove('show');
+            loginToast.classList.add('hidden');
+        }, 3000);
+    }
+
+    loginForm.addEventListener('submit', async function(event) {
+        event.preventDefault();
+
+        const login = loginInput.value.trim();
+        const password = passwordInput.value.trim();
+
+        const { data, error } = await window.supabaseClient.auth.signInWithPassword({
+            email: login,
+            password: password,
+        });
+
+        if (error) {
+            console.error('Login error:', error);
+            if (error.status === 401 || error.status === 403) {
+                showToast('Nieprawidłowe dane logowania.', 'error');
+            } else {
+                showToast(error.message, 'error');
+            }
+        } else {
+            localStorage.setItem('currentUser', JSON.stringify(data.user));
+            showToast('Zalogowano pomyślnie!', 'success');
+            setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        }
+    });
+});

--- a/login.html
+++ b/login.html
@@ -1,16 +1,53 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Logowanie do Systemu</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Logowanie użytkownika</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/login.css">
 </head>
-<body class="bg-gray-100">
-    <div id="root"></div>
-    <script type="module" src="./src/main.jsx"></script>
+<body class="flex items-center justify-center min-h-screen bg-gray-100 p-4">
+    <div class="bg-white p-8 rounded-xl shadow-lg w-full max-w-md text-center">
+        <div class="mb-8 flex justify-center">
+            <img src="assets/img/zis-zawadzki-logo.png" alt="ZIS Zawadzki">
+        </div>
+
+        <h2 class="text-3xl font-bold text-gray-800 mb-6">Zaloguj się</h2>
+
+        <form id="login-form" class="space-y-6">
+            <div>
+                <label for="login" class="sr-only">Login</label>
+                <input type="email" id="login" name="login" placeholder="Email" required
+                       class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-red-500 focus:border-red-500 text-gray-800 placeholder-gray-500">
+            </div>
+            <div>
+                <label for="password" class="sr-only">Hasło</label>
+                <input type="password" id="password" name="password" placeholder="Hasło" required
+                       class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-red-500 focus:border-red-500 text-gray-800 placeholder-gray-500">
+            </div>
+            <button type="submit"
+                    class="w-full brand-accent hover:bg-[#F2AC73] text-white font-bold py-3 px-4 rounded-lg transition duration-200 ease-in-out">
+                Zaloguj się
+            </button>
+        </form>
+
+        <div class="mt-6 text-sm text-gray-600">
+            <a href="register.html" class="brand-accent-text hover:underline">Nie masz konta? Zarejestruj się</a>
+        </div>
+
+        <div id="login-toast" class="toast fixed bottom-5 right-5 bg-gray-800 text-white py-3 px-5 rounded-lg shadow-lg flex items-center space-x-3 z-50 hidden">
+            <i class="fas fa-info-circle text-blue-400"></i>
+            <span id="toast-message"></span>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="assets/js/supabaseClient.js"></script>
+    <script src="assets/js/login.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restore static login page with Tailwind styling and toast notifications
- hook login form to Supabase sign-in and store user in localStorage
- ignore runtime artifacts with a new `.gitignore`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68947e19a82083269923de4344033ebf