### PR TITLE
Use full name for profile select options

### DIFF
--- a/assets/js/contacts.js
+++ b/assets/js/contacts.js
@@ -48,7 +48,11 @@ document.addEventListener("DOMContentLoaded", function () {
   let selectsLoaded = false;
 
   async function loadSelectOptions() {
-    await populateSelect("profiles", document.getElementById("contact-owner"));
+    await populateSelect(
+      "profiles",
+      document.getElementById("contact-owner"),
+      "full_name"
+    );
     await populateSelect(
       "contact_types",
       document.getElementById("contact-type")


### PR DESCRIPTION
## Summary
- Ensure contacts profile dropdown displays `full_name` instead of default `name`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895b670edb08326ab8bebd4e819b686